### PR TITLE
Feature/request retrier

### DIFF
--- a/fit-checker.xcodeproj/project.pbxproj
+++ b/fit-checker.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		D245B32B1E317D410074CB5B /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D245B32A1E317D410074CB5B /* SettingsViewController.swift */; };
 		D245B32D1E3181530074CB5B /* KeychainAccess+Keechain.swift in Sources */ = {isa = PBXBuildFile; fileRef = D245B32C1E3181530074CB5B /* KeychainAccess+Keechain.swift */; };
 		D245B3301E3183CA0074CB5B /* LogoutOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D245B32F1E3183CA0074CB5B /* LogoutOperation.swift */; };
+		D27C56701E32B0BA00EC9C40 /* EduxRetrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27C566F1E32B0BA00EC9C40 /* EduxRetrier.swift */; };
+		D27C56721E32C0F700EC9C40 /* EduxValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27C56711E32C0F700EC9C40 /* EduxValidators.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -386,6 +388,8 @@
 		D245B32A1E317D410074CB5B /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		D245B32C1E3181530074CB5B /* KeychainAccess+Keechain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "KeychainAccess+Keechain.swift"; sourceTree = "<group>"; };
 		D245B32F1E3183CA0074CB5B /* LogoutOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogoutOperation.swift; sourceTree = "<group>"; };
+		D27C566F1E32B0BA00EC9C40 /* EduxRetrier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EduxRetrier.swift; sourceTree = "<group>"; };
+		D27C56711E32C0F700EC9C40 /* EduxValidators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EduxValidators.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -850,6 +854,8 @@
 				D2352E451E284E3500303424 /* operations */,
 				D2352E411E28481200303424 /* NetworkController.swift */,
 				D2352E431E28487700303424 /* EduxRouter.swift */,
+				D27C566F1E32B0BA00EC9C40 /* EduxRetrier.swift */,
+				D27C56711E32C0F700EC9C40 /* EduxValidators.swift */,
 			);
 			path = networking;
 			sourceTree = "<group>";
@@ -1094,6 +1100,7 @@
 				D245B3271E30309B0074CB5B /* Lecture.swift in Sources */,
 				D245B32D1E3181530074CB5B /* KeychainAccess+Keechain.swift in Sources */,
 				D245B3291E3030A50074CB5B /* LectureListParser.swift in Sources */,
+				D27C56721E32C0F700EC9C40 /* EduxValidators.swift in Sources */,
 				4D279A701E2A21CB00542E0B /* ClasificationParsing.swift in Sources */,
 				D2352E331E27EFDF00303424 /* ClassificationRow.swift in Sources */,
 				D245B3281E3030A20074CB5B /* LectureListParsing.swift in Sources */,
@@ -1102,6 +1109,7 @@
 				4D52968F1E2A4C28007677BA /* FileLoader.swift in Sources */,
 				D245B3261E3030980074CB5B /* LectureListResult.swift in Sources */,
 				D2352E341E27EFDF00303424 /* ClassificationTable.swift in Sources */,
+				D27C56701E32B0BA00EC9C40 /* EduxRetrier.swift in Sources */,
 				D245B30B1E2D40B90074CB5B /* ContextManager.swift in Sources */,
 				D2352E491E284EA300303424 /* ReadCourseClassificationOperation.swift in Sources */,
 				D2352E531E2A0CDF00303424 /* BaseOperation.swift in Sources */,

--- a/fit-checker/AppDelegate.swift
+++ b/fit-checker/AppDelegate.swift
@@ -81,7 +81,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         coursesController.tabBarItem = UITabBarItem(title: "Courses", image:
             nil, selectedImage: nil)
-        settingsController.tabBarItem = UITabBarItem(title: "Courses", image:
+        settingsController.tabBarItem = UITabBarItem(title: "Settings", image:
             nil, selectedImage: nil)
 
         let controllers = [

--- a/fit-checker/networking/EduxRetrier.swift
+++ b/fit-checker/networking/EduxRetrier.swift
@@ -1,0 +1,83 @@
+//
+//  EduxRetrier.swift
+//  fit-checker
+//
+//  Created by Josef Dolezal on 20/01/2017.
+//  Copyright © 2017 Josef Dolezal. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+
+/// Allows to retry failed operations. If operation failed because of
+/// missing cookies (uh, authorization) retrier tryes to login
+/// user with stored credential and if it's successfull, calls original
+/// request again.
+class EduxRetrier: RequestRetrier {
+
+    /// Network request manager -
+    private weak var networkController: NetworkController?
+
+    /// Thread safe token refreshning indicator
+    private var isRefreshing = false
+
+    /// Synchronizing queue
+    private let accessQueue = DispatchQueue(label: "EduxRetrier")
+
+    init(networkController: NetworkController) {
+        self.networkController = networkController
+    }
+
+    /// Determines wheter
+    ///
+    /// - Parameters:
+    ///   - manager: Requests session manager
+    ///   - request: Failed request
+    ///   - error: Request error
+    ///   - completion: Retry decision
+    public func should(_ manager: SessionManager, retry request: Request,
+                       with error: Error,
+                       completion: @escaping RequestRetryCompletion) {
+
+        print("Ooops, request failed")
+
+        // Run validation on serial queue
+        accessQueue.async { [weak self] in
+            let keychain = Keechain(service: .edux)
+
+            // Retry only on recognized errors
+            guard
+                case EduxValidators.ValidationError.badCredentials = error else {
+
+                print("Unrecognized error, not retrying.")
+                completion(false, 0.0)
+                return
+            }
+
+            guard
+                self?.isRefreshing == false,
+                let networkController = self?.networkController,
+                let (username, password) = keychain.getAccount() else { return }
+
+
+            print("Retrying request")
+
+            self?.isRefreshing = true
+
+            let promise = networkController.authorizeUser(with: username,
+                                                          password: password)
+
+            // Try to authorize user
+            promise.success = {
+                completion(true, 0.0)
+            }
+
+            promise.failure = {
+                completion(false, 0.0)
+            }
+
+            self?.isRefreshing = false
+        }
+    }
+}

--- a/fit-checker/networking/EduxRetrier.swift
+++ b/fit-checker/networking/EduxRetrier.swift
@@ -11,7 +11,7 @@ import Alamofire
 
 
 /// Allows to retry failed operations. If operation failed because of
-/// missing cookies (uh, authorization) retrier tryes to login
+/// missing cookies (uh, authorization) retrier tries to login
 /// user with stored credential and if it's successfull, calls original
 /// request again.
 class EduxRetrier: RequestRetrier {

--- a/fit-checker/networking/EduxValidators.swift
+++ b/fit-checker/networking/EduxValidators.swift
@@ -1,0 +1,84 @@
+//
+//  EduxValidators.swift
+//  fit-checker
+//
+//  Created by Josef Dolezal on 20/01/2017.
+//  Copyright © 2017 Josef Dolezal. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+
+struct EduxValidators {
+
+    /// Shared validator constants
+    struct Constants {
+        /// If verifier is contained in HTML response, user is logged in
+        static let loginHTMLVerifier = "Odhlásit se"
+
+        /// If verifier is contained in JSON response, user is logged in
+        static let loginJSONVerifier = "Studuji:"
+    }
+
+    /// Possible edux validation errors
+    ///
+    /// - generalError: Unrecognized error during request processing
+    /// - badCredentials: User is not logged in
+    enum ValidationError: Error {
+        case generalError
+        case badCredentials
+    }
+
+    /// Checks whether user is logged in (for HTML requests only)
+    ///
+    /// - Parameters:
+    ///   - request: Original URL request
+    ///   - response: Server response
+    ///   - data: Response data
+    /// - Returns: Failure if login was not successfull, success otherwise
+    static func validateLoginHTML(request: URLRequest?, response:
+        HTTPURLResponse, data: Data?) -> Request.ValidationResult {
+
+        return dataContainsVerifier(data: data, verifier:
+            Constants.loginHTMLVerifier)
+    }
+
+    /// Checks whether user is logged in (for JSON requests only)
+    ///
+    /// - Parameters:
+    ///   - request: Original URL request
+    ///   - response: Server response
+    ///   - data: Response data
+    /// - Returns: Failure if login was not successfull, success otherwise
+    static func validateLoginJSON(request: URLRequest?, response:
+        HTTPURLResponse, data: Data?) -> Request.ValidationResult {
+
+        return dataContainsVerifier(data: data, verifier:
+            Constants.loginJSONVerifier)
+    }
+
+    /// Checks if response containts verifier
+    ///
+    /// - Parameters:
+    ///   - data: Response body
+    ///   - verifier: Verifier which should be in body
+    /// - Returns: .success if validator is presented, .failure otherwise
+    private static func dataContainsVerifier(data: Data?, verifier:
+        String) -> Request.ValidationResult {
+
+        guard
+            // This is legit since both JSON and HTML
+            // response should have body and the body
+            // should be representable by string
+            let data = data,
+            let html = String(data: data, encoding: .utf8) else {
+
+                return .failure(ValidationError.generalError)
+        }
+
+        return html.contains(verifier)
+            ? .success
+            : .failure(ValidationError.badCredentials)
+    }
+}

--- a/fit-checker/networking/NetworkController.swift
+++ b/fit-checker/networking/NetworkController.swift
@@ -32,6 +32,12 @@ class NetworkController {
 
     init(contextManager: ContextManager) {
         self.contextManager = contextManager
+
+        // This is safe because network controller is
+        // weak property, so no reference cycle should occure
+        let retrier = EduxRetrier(networkController: self)
+
+        sessionManager.retrier = retrier
     }
 
     /// Allows to authorize user to Edux with username and password

--- a/fit-checker/networking/operations/EduxLoginOperation.swift
+++ b/fit-checker/networking/operations/EduxLoginOperation.swift
@@ -51,7 +51,7 @@ class EduxLoginOperation: BaseOperation {
     override func start() {
         _ = sessionManager.request(EduxRouter.login(query: queryParameters,
                                                     body: bodyParameters))
-            .validate().validate(EduxValidators.validateLoginHTML)
+            .validate().validate(EduxValidators.validCredentials)
             .response(completionHandler: handle)
     }
 

--- a/fit-checker/networking/operations/EduxLoginOperation.swift
+++ b/fit-checker/networking/operations/EduxLoginOperation.swift
@@ -51,31 +51,8 @@ class EduxLoginOperation: BaseOperation {
     override func start() {
         _ = sessionManager.request(EduxRouter.login(query: queryParameters,
                                                     body: bodyParameters))
-            .validate().validate(EduxLoginOperation.validateLogin)
+            .validate().validate(EduxValidators.validateLoginHTML)
             .response(completionHandler: handle)
-    }
-
-    /// Checks whether user login was successfull.
-    ///
-    /// - Parameters:
-    ///   - request: Original URL request
-    ///   - response: Server response
-    ///   - data: Response data
-    /// - Returns: Failure if login was not successfull, success otherwise
-    static func validateLogin(request: URLRequest?,
-                              response: HTTPURLResponse, data: Data?)
-        -> Request.ValidationResult {
-
-            guard
-                let data = data,
-                let html = String(data: data, encoding: .utf8) else {
-
-                return .failure(EduxLoginOperationError.generalError)
-            }
-
-            return html.contains(EduxLoginOperation.loginIdentifier)
-                ? .failure(EduxLoginOperationError.badCredentials)
-                : .success
     }
 
     /// Finishes operation based on validation results.
@@ -101,13 +78,4 @@ class EduxLoginOperation: BaseOperation {
             promise?.failure()
         }
     }
-}
-
-/// Possible Edux login error.
-///
-/// - generalError: Occures when server response is not valid html or has bad response code
-/// - badCredentials: Thrown when user credentials are not valid
-enum EduxLoginOperationError: Error {
-    case generalError
-    case badCredentials
 }

--- a/fit-checker/networking/operations/ReadCourseClassificationOperation.swift
+++ b/fit-checker/networking/operations/ReadCourseClassificationOperation.swift
@@ -30,7 +30,7 @@ class ReadCourseClassificationOperation: BaseOperation {
         _ = sessionManager.request(EduxRouter.courseClassification(
             courseId: courseId, student: student))
             .validate()
-            .validate(EduxValidators.validateLoginHTML)
+            .validate(EduxValidators.authorizedHTML)
             .responseString(completionHandler: handle)
     }
 

--- a/fit-checker/networking/operations/ReadCourseClassificationOperation.swift
+++ b/fit-checker/networking/operations/ReadCourseClassificationOperation.swift
@@ -29,8 +29,9 @@ class ReadCourseClassificationOperation: BaseOperation {
     override func start() {
         _ = sessionManager.request(EduxRouter.courseClassification(
             courseId: courseId, student: student))
-            .validate().responseString(
-                completionHandler: handle)
+            .validate()
+            .validate(EduxValidators.validateLoginHTML)
+            .responseString(completionHandler: handle)
     }
 
     /// Handle HTML response

--- a/fit-checker/networking/operations/ReadCourseListOperation.swift
+++ b/fit-checker/networking/operations/ReadCourseListOperation.swift
@@ -38,7 +38,7 @@ class ReadCourseListOperation: BaseOperation {
             body: ReadCourseListOperation.body)
             )
             .validate()
-            .validate(EduxValidators.validateLoginJSON)
+            .validate(EduxValidators.authorizedJSON)
             .responseJSON(completionHandler: handle)
     }
 

--- a/fit-checker/networking/operations/ReadCourseListOperation.swift
+++ b/fit-checker/networking/operations/ReadCourseListOperation.swift
@@ -38,6 +38,7 @@ class ReadCourseListOperation: BaseOperation {
             body: ReadCourseListOperation.body)
             )
             .validate()
+            .validate(EduxValidators.validateLoginJSON)
             .responseJSON(completionHandler: handle)
     }
 
@@ -55,7 +56,6 @@ class ReadCourseListOperation: BaseOperation {
 
         switch response.result {
         case let .success(json):
-            try! print(String(data: JSONSerialization.data(withJSONObject: json, options: []), encoding: .utf8))
             guard let json = json as? [String: Any?] else { return }
 
             let parser = LectureListParser()


### PR DESCRIPTION
Implementace automatického přelogování v případě, že requesty selhaly z důvodu neplatného přihlášení. To mohlo nastat při zapnutí aplikace (v session nebyly ještě cookies) nebo při vypršení platnosti cookies. Retrier zkouší opakuje jen requesty, které neprošly validací `authorizedHTML` nebo `authorizedJSON`.